### PR TITLE
feat(cli): return nonzero exit code on failed validation

### DIFF
--- a/bin/validate.js
+++ b/bin/validate.js
@@ -12,7 +12,10 @@ program
   .option('-s, --schema [schemaPath]','path to an external schema file')
   .action((options) => {
     const targetObj = options.targetObj ? JSON.parse(options.targetObj) : options.filePath
-    validateSchema(targetObj, options)
+    const errorsAndWarnings = validateSchema(targetObj, options)
+    if (errorsAndWarnings?.length > 0) {
+      process.exit(1)
+    }
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
addresses #17

the `validate` function currently returns an aggregation of errors and warnings, if any were found.
This gives us the opportunity to make the process return a nonzero status code, which makes it possible to use the CLI in Continuous Integration or git hooks.