### PR TITLE
Always checkout index.js with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Force line endings for index.js to unix-style.
+# Unlike npm, yarn does not convert line endings of bin-files.
+# This means that package releases from a windows machine will end up on unix file systems with crlf line endings, and will not be executable from a command-line.
+/index.js eol=lf


### PR DESCRIPTION
Force line endings for index.js to unix-style.
Unlike npm, yarn does not convert line endings of bin-files.
This means that package releases from a windows machine will end up on unix file systems with crlf line endings, and will not be executable from a command-line.

I assume that publishing of the package occurs on a windows machine, hence the existence of the CRLF line endings.
An alternative solution would be to change the line endings prior to publishing the package.

After merging this it will be necessary for already installed copies of the repository to re-normalize the line feeds of files.

Closes https://github.com/ketanSaxena/schema-validator/issues/22