### PR TITLE
Returns only error when log level set to error, else return all

### DIFF
--- a/lib/print_errors.js
+++ b/lib/print_errors.js
@@ -8,9 +8,11 @@ const printErrors = (errors, warnings, logLevel = 3) => {
     }
     if(logLevel) {
       errors.forEach((err, index) => logger.red(`${index + 1}. ${err.message}`))
+      return errors
     }
     if(logLevel > 1) {
       warnings.forEach((warn, index) => logger.yellow(`${index + 1}. ${warn.message}`))
+      return errors.concat(warnings)
     }
   } else if(logLevel > 2) {
     logger.success('Schema Validated Successfully')


### PR DESCRIPTION
Fixing the issue where log level error return error+warnings.
https://github.com/ketanSaxena/schema-validator/issues/21
